### PR TITLE
Optimize Nuxt performance and prerender static routes

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,7 +1,8 @@
 <template>
   <UApp>
-    <NuxtPage />
-      <NuxtLayout />
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
   </UApp>
 </template>
 

--- a/app/components/CommandPalette.vue
+++ b/app/components/CommandPalette.vue
@@ -28,6 +28,7 @@ const secretEnabled = useState('secretEnabled', () => false)
 const brainrotLevel = useState('brainrotLevel', () => parseInt(runtimeConfig.public.defaultBrainrotLevel) || 0)
 const router = useRouter()
 const toast = useToast()
+const colorMode = useColorMode()
 
 const commandGroups = computed(() => [
   {
@@ -65,7 +66,6 @@ const commandGroups = computed(() => [
         icon: 'i-heroicons-moon',
         label: 'Toggle Dark Mode',
         onClick() {
-          const colorMode = useColorMode()
           colorMode.preference = colorMode.value === 'dark' ? 'light' : 'dark'
         },
       },
@@ -74,12 +74,7 @@ const commandGroups = computed(() => [
         icon: 'i-heroicons-key',
         label: 'Silver Key',
         onClick() {
-          toast.add({
-            title: 'Hmm...',
-            description: 'Seems like it doesn\'t work...',
-            icon: 'i-heroicons-lock-closed',
-            duration: 3500
-          })
+          showLockedKeyToast()
         },
       },
       {
@@ -87,12 +82,7 @@ const commandGroups = computed(() => [
         icon: 'i-heroicons-key',
         label: 'Bronze Key',
         onClick() {
-          toast.add({
-            title: 'Hmm...',
-            description: 'Seems like it doesn\'t work...',
-            icon: 'i-heroicons-lock-closed',
-            duration: 3500
-          })
+          showLockedKeyToast()
         },
       },
       {
@@ -115,12 +105,7 @@ const commandGroups = computed(() => [
         icon: 'i-heroicons-key',
         label: 'Rusty Key',
         onClick() {
-          toast.add({
-            title: 'Hmm...',
-            description: 'Seems like it doesn\'t work...',
-            icon: 'i-heroicons-lock-closed',
-            duration: 3500
-          })
+          showLockedKeyToast()
         },
       },
       {
@@ -128,12 +113,7 @@ const commandGroups = computed(() => [
         icon: 'i-heroicons-key',
         label: 'Crystal Key',
         onClick() {
-          toast.add({
-            title: 'Hmm...',
-            description: 'Seems like it doesn\'t work...',
-            icon: 'i-heroicons-lock-closed',
-            duration: 3500
-          })
+          showLockedKeyToast()
         },
       },
     ],
@@ -239,11 +219,18 @@ const commandGroups = computed(() => [
   },
 ])
 
+function showLockedKeyToast() {
+  toast.add({
+    title: 'Hmm...',
+    description: 'Seems like it doesn\'t work...',
+    icon: 'i-heroicons-lock-closed',
+    duration: 3500
+  })
+}
+
 function handleSelect(item) {
   if (!item) return
 
-  console.log('Selected item:', item)
-  
   if (item.onClick && typeof item.onClick === 'function') {
     item.onClick()
   } else if (item.onSelect && typeof item.onSelect === 'function') {

--- a/app/components/SecretHint.vue
+++ b/app/components/SecretHint.vue
@@ -16,9 +16,9 @@ const hints = [
 
 const showRandomHint = () => {
   if (secretEnabled.value) return
-  
+
   const randomHint = hints[Math.floor(Math.random() * hints.length)]
-  
+
   toast.add({
     title: 'Hmm?',
     description: randomHint,
@@ -28,24 +28,26 @@ const showRandomHint = () => {
   })
 }
 
-watch(isSettingsModalOpen, (newValue) => {
-  if (newValue && !secretEnabled.value) {
-    const shouldShowHint = Math.random() < 0.5
-    
-    if (shouldShowHint) {
-      showRandomHint()
-    }
-  }
-})
+if (import.meta.client) {
+  watch(isSettingsModalOpen, (newValue) => {
+    if (newValue && !secretEnabled.value) {
+      const shouldShowHint = Math.random() < 0.5
 
-onMounted(() => {
-  const hintsEnabled = runtimeConfig.public.enableSecretHint === 'true'
-  if (hintsEnabled) {
-    const shouldShowHint = Math.random() < 0.2
-    
-    if (shouldShowHint) {
-      showRandomHint()
+      if (shouldShowHint) {
+        showRandomHint()
+      }
     }
-  }
-})
+  })
+
+  onMounted(() => {
+    const hintsEnabled = runtimeConfig.public.enableSecretHint === 'true'
+    if (hintsEnabled) {
+      const shouldShowHint = Math.random() < 0.2
+
+      if (shouldShowHint) {
+        showRandomHint()
+      }
+    }
+  })
+}
 </script>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -12,9 +12,12 @@
         />
       </div>
 
-      <CommandPalette ref="commandPaletteRef" @unlock-secret="secretEnabled = true" />
-      <Settings v-model="isSettingsModalOpen" />
-      <SecretHint />
+      <LazyCommandPalette
+        ref="commandPaletteRef"
+        @unlock-secret="secretEnabled = true"
+      />
+      <LazySettings v-model="isSettingsModalOpen" />
+      <LazySecretHint hydrate-on-idle />
 
       <slot />
 
@@ -36,10 +39,6 @@
 </template>
 
 <script setup lang="ts">
-import Settings from '~/components/Settings.vue'
-import CommandPalette from '~/components/CommandPalette.vue'
-import SecretHint from '~/components/SecretHint.vue'
-
 const isSettingsModalOpen = useState('settingsModal', () => false)
 const secretEnabled = useState('secretEnabled', () => false)
 const commandPaletteRef = ref(null)

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -111,94 +111,104 @@
       </div>
     </main>
 
-    <UModal v-model:open="isContactModalOpen">
-      <template #default>
-        <!-- Empty default slot -->
-      </template>
-      
-      <template #content>
-        <UCard>
-          <template #header>
-            <h3 class="text-lg font-semibold">Business Inquiries Only</h3>
-          </template>
+    <ClientOnly>
+      <UModal v-model:open="isContactModalOpen">
+        <template #default>
+          <!-- Empty default slot -->
+        </template>
 
-          <p class="text-gray-600 dark:text-gray-400 mb-4">
-            Please proceed only if you represent a company.
-            Fan mail will not be responded to :(
-          </p>
+        <template #content>
+          <UCard>
+            <template #header>
+              <h3 class="text-lg font-semibold">Business Inquiries Only</h3>
+            </template>
 
-          <template #footer>
-            <div class="flex flex-col gap-2">
-              <UButton
-                block
-                size="xl"
-                color="error"
-                @click="openEmailModal"
-                label="I understand, continue"
-              />
-              <UButton
-                block
-                color="neutral"
-                size="xl"
-                variant="ghost"
-                @click="isContactModalOpen = false"
-                label="Go back.."
-              />
+            <p class="text-gray-600 dark:text-gray-400 mb-4">
+              Please proceed only if you represent a company.
+              Fan mail will not be responded to :(
+            </p>
+
+            <template #footer>
+              <div class="flex flex-col gap-2">
+                <UButton
+                  block
+                  size="xl"
+                  color="error"
+                  @click="openEmailModal"
+                  label="I understand, continue"
+                />
+                <UButton
+                  block
+                  color="neutral"
+                  size="xl"
+                  variant="ghost"
+                  @click="isContactModalOpen = false"
+                  label="Go back.."
+                />
+              </div>
+            </template>
+          </UCard>
+        </template>
+      </UModal>
+
+      <UModal v-model:open="isEmailModalOpen">
+        <template #default>
+          <!-- Empty default slot -->
+        </template>
+
+        <template #content>
+          <UCard>
+            <template #header>
+              <h3 class="text-lg font-semibold">Contact</h3>
+            </template>
+
+            <div class="space-y-4 mb-4">
+
+              <UFormField label="Mail">
+                <UButton
+                  variant="ghost"
+                  icon="i-heroicons-clipboard"
+                  class="font-mono w-full dark:bg-gray-800 dark:hover:bg-gray-700 bg-gray-100 hover:bg-gray-200"
+                  @click="copyEmail"
+                >
+                  {{ runtimeConfig.public.email }}
+                </UButton>
+              </UFormField>
+
+              <UFormField label="Manager's Discord">
+                <UButton
+                  variant="ghost"
+                  icon="i-heroicons-clipboard"
+                  class="font-mono w-full dark:bg-gray-800 dark:hover:bg-gray-700 bg-gray-100 hover:bg-gray-200"
+                  @click="copyDiscord"
+                >
+                  {{ runtimeConfig.public.managerDiscord }}
+                </UButton>
+              </UFormField>
             </div>
-          </template>
-        </UCard>
-      </template>
-    </UModal>
 
-    <UModal v-model:open="isEmailModalOpen">
-      <template #default>
-        <!-- Empty default slot -->
-      </template>
-      
-      <template #content>
-        <UCard>
-          <template #header>
-            <h3 class="text-lg font-semibold">Contact</h3>
-          </template>
-
-          <div class="space-y-4 mb-4">
-            
-            <UFormField label="Mail">
-              <UButton
-                variant="ghost"
-                icon="i-heroicons-clipboard"
-                class="font-mono w-full dark:bg-gray-800 dark:hover:bg-gray-700 bg-gray-100 hover:bg-gray-200"
-                @click="copyEmail"
-              >
-                {{ runtimeConfig.public.email }}
-              </UButton>
-            </UFormField>
-            
-            <UFormField label="Manager's Discord">
-              <UButton
-                variant="ghost"
-                icon="i-heroicons-clipboard"
-                class="font-mono w-full dark:bg-gray-800 dark:hover:bg-gray-700 bg-gray-100 hover:bg-gray-200"
-                @click="copyDiscord"
-              >
-                {{ runtimeConfig.public.managerDiscord }}
-              </UButton>
-            </UFormField>
-          </div>
-
-          <p class="text-sm text-gray-500 text-center">
-            Click to copy
-          </p>
-        </UCard>
-      </template>
-    </UModal>
+            <p class="text-sm text-gray-500 text-center">
+              Click to copy
+            </p>
+          </UCard>
+        </template>
+      </UModal>
+    </ClientOnly>
   </UContainer>
 </template>
 
 <script setup lang="ts">
 const runtimeConfig = useRuntimeConfig()
-const colorMode = useColorMode()
+const toast = useToast()
+
+definePageMeta({
+  prerender: true
+})
 const useCopy = async (text) => {
+  if (typeof navigator === 'undefined' || !navigator.clipboard) {
+    return false
+  }
+
   try {
     await navigator.clipboard.writeText(text)
     return true
@@ -208,10 +218,8 @@ const useCopy = async (text) => {
   }
 }
 
-const isContactModalOpen = useState('contactModal', () => false)
-const isEmailModalOpen = useState('emailModal', () => false)
-const isSettingsModalOpen = useState('settingsModal', () => false)
-const magicEnabled = useState('magicEnabled', () => false)
+const isContactModalOpen = ref(false)
+const isEmailModalOpen = ref(false)
 const brainrotLevel = useState('brainrotLevel', () => parseInt(runtimeConfig.public.defaultBrainrotLevel) || 0)
 
 const baseLinks = [
@@ -301,7 +309,6 @@ const openEmailModal = () => {
 
 const copyEmail = async () => {
   await useCopy(runtimeConfig.public.email)
-  const toast = useToast()
   toast.add({
     title: 'Copied!',
     description: 'Now my email address is somewhere in your clipboard..',
@@ -313,7 +320,6 @@ const copyEmail = async () => {
 
 const copyDiscord = async () => {
   await useCopy(runtimeConfig.public.managerDiscord)
-  const toast = useToast()
   toast.add({
     title: 'Copied!',
     description: 'Please do not annoy my manager..',

--- a/app/pages/portfolio.vue
+++ b/app/pages/portfolio.vue
@@ -54,11 +54,11 @@
             <template v-for="project in projects" :key="project.label" #[project.label]>
               <p class="mb-4">{{ project.content }}</p>
               <div class="relative pb-[56.25%] h-0 overflow-hidden rounded-lg shadow-md">
-                <ScriptYouTubePlayer ref="video" :video-id="project.videoId">
+                <LazyScriptYouTubePlayer ref="video" :video-id="project.videoId" hydrate-on-visible>
                   <template #placeholder="{ placeholder }">
                     <img :src="placeholder" alt="Video Placeholder" class="absolute top-0 left-0 w-full h-full">
                   </template>
-                </ScriptYouTubePlayer>
+                </LazyScriptYouTubePlayer>
               </div>
             </template>
           </UTabs>
@@ -114,9 +114,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref } from 'vue'
 
 const runtimeConfig = useRuntimeConfig()
+
+definePageMeta({
+  prerender: true
+})
 const projects = [
   {
     icon: 'i-ri-movie-2-fill',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,9 +4,26 @@ export default defineNuxtConfig({
 
   modules: ['@nuxt/ui', '@nuxt/eslint', '@nuxt/image', "@nuxt/scripts"],
 
+  experimental: {
+    defaults: {
+      nuxtLink: {
+        prefetchOn: 'interaction',
+      },
+    },
+  },
+
   css: ['~/assets/css/main.css'],
   nitro: {
     preset: 'vercel',
+  },
+
+  routeRules: {
+    '/': {
+      prerender: true,
+    },
+    '/portfolio': {
+      prerender: true,
+    },
   },
 
   future: {


### PR DESCRIPTION
## Summary
- defer non-critical interactivity by lazily hydrating the secret hint widget and reusing shared state inside the command palette
- wrap client-only modals and guard clipboard access while pre-rendering the homepage and portfolio for faster navigation
- enable NuxtLink interaction-only prefetching and lazy YouTube embeds to trim initial bundle work

## Testing
- npm install *(fails: registry returns 403 for @iconify-json/heroicons)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913b27b971c832c8443319edfe0c104)